### PR TITLE
Fixed an issue with duplicate keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ function getJsonVariable([string]$variableName){
 	$fullVariableDeclaration = "var $variableName = ";
 	$lineRaw = $requestLogin.Content  -split '\r?\n' | Select-String $fullVariableDeclaration;
 	$lineRaw = $lineRaw -replace $fullVariableDeclaration,''
+	$lineRaw = $lineRaw.Replace('filename', 'filename2')
 	$lineRaw = $lineRaw -replace ';',''
 	return $lineRaw | ConvertFrom-Json;
 }


### PR DESCRIPTION
Fixed duplicate keys. There are duplicate keys in present called 'fileName' and 'filename' causing an issue when running ConvertFrom-Json. The values of them are the same. Issue resolved by renaming one of the keys.